### PR TITLE
Fix import path for local search index in VPLocalSearchBox - Fix #234

### DIFF
--- a/packages/theme/src/theme/components/VPLocalSearchBox.vue
+++ b/packages/theme/src/theme/components/VPLocalSearchBox.vue
@@ -44,7 +44,7 @@ const searchIndexData = shallowRef(localSearchIndex)
 
 // hmr
 if (import.meta.hot) {
-  import.meta.hot.accept('/@localSearchIndex', (m) => {
+  import.meta.hot.accept('@localSearchIndex', (m) => {
     if (m) {
       searchIndexData.value = m.default
     }


### PR DESCRIPTION
Reflecting changes from the native component:
https://github.com/vuejs/vitepress/blob/17696c358b88335c4f6bb516bbcdf774aaf7deee/src/client/theme-default/components/VPLocalSearchBox.vue#L49