### PR TITLE
docs: link design system and contributor guide from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,18 @@ To use this project, follow these docs:
 - [VitePress](https://vitepress.dev/)
 - [Markdown](https://www.markdownguide.org/)
 
+## Design system
+
+Carbon has a documented design language — color roles, typography, spacing, shape,
+and elevation, with light and dark values for every token. Read
+[design.md](design.md) before changing any UI, and build with the `--vp-*` tokens
+in [`packages/theme/src/theme/styles/vars.css`](packages/theme/src/theme/styles/vars.css)
+rather than hardcoded values.
+
 ## Contribution Guide
+
+Before contributing, read [AGENTS.md](AGENTS.md) — the setup, commands,
+conventions, and workflow that apply to human and automated contributors alike.
 
 We use `pnpm` as our package manager. To get started, run:
 


### PR DESCRIPTION
## Summary

Surfaces the new docs from the README so they're discoverable from the front page:

- A **Design system** section linking to `design.md` and the `--vp-*` token source.
- A pointer to `AGENTS.md` at the top of the **Contribution Guide**.

Docs only — a single-file README change.

## Note

This is stacked on `docs/ai-workflow` (#289) because it links to `design.md` and
`AGENTS.md`, which land in that PR. The base retargets to `main` automatically
once #289 merges.
