### PR TITLE
feat(theme): contribution-graph footer with a call to action

### DIFF
--- a/packages/demo/.vitepress/config.mts
+++ b/packages/demo/.vitepress/config.mts
@@ -99,7 +99,17 @@ export default defineConfigWithTheme<ThemeConfig>({
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/brenoepics/vitepress-carbon' }
-    ]
+    ],
+
+    footer: {
+      action: {
+        text: 'Create Repository',
+        link: 'https://github.com/new?template_name=carbon-starter&template_owner=brenoepics'
+      },
+      message:
+        'Released under the <a href="https://github.com/brenoepics/vitepress-carbon/blob/main/LICENSE">MIT License</a>.',
+      copyright: `Copyright © 2024–${new Date().getFullYear()} <a href="https://github.com/brenoepics">Breno A.</a>`
+    }
   },
 
   markdown: {

--- a/packages/demo/src/guide/components.md
+++ b/packages/demo/src/guide/components.md
@@ -366,23 +366,27 @@ The decorative grid behind the footer — a GitHub contribution graph rendered
 from a deterministic hash, so the server and client always produce the same
 pattern. Useful on its own for any band that wants the same texture.
 
-Two masks are intersected so the grid reads as a chevron pointing inwards:
-one fades it towards the page centre (which edge depends on `side`), the other
-hollows out the vertical middle so text placed over it stays legible.
+`mask="frame"` punches an ellipse out of the middle, leaving the grid
+continuous around all four edges — this is what the footer uses, so the
+tiles close around the content instead of stopping at a hard edge. The hollow
+is sized with `--vp-tiles-hollow-w` / `--vp-tiles-hollow-h` (defaults `40%`
+and `62%`), which is how the footer widens it on narrow screens.
 
 ```vue
 <script setup>
 import { VPContributionTiles } from 'vitepress-carbon/components'
 </script>
 
-<VPContributionTiles side="left" :columns="20" :rows="22" />
+<VPContributionTiles mask="frame" :columns="120" :rows="18" />
+<VPContributionTiles mask="fade" side="left" :columns="20" :rows="7" />
 ```
 
-| Prop      | Type                | Default  | Description                                      |
-| --------- | ------------------- | -------- | ------------------------------------------------ |
-| `side`    | `'left' \| 'right'` | `'left'` | Edge the grid fades away from.                   |
-| `columns` | `number`            | `16`     | Grid width in cells.                             |
-| `rows`    | `number`            | `7`      | Grid height. Seven matches a real weekday graph. |
+| Prop      | Type                          | Default  | Description                                               |
+| --------- | ----------------------------- | -------- | --------------------------------------------------------- |
+| `mask`    | `'fade' \| 'frame' \| 'none'` | `'fade'` | `frame` hollows out the centre; `fade` thins to one edge. |
+| `side`    | `'left' \| 'right'`           | `'left'` | Edge to fade towards. Only used when `mask` is `fade`.    |
+| `columns` | `number`                      | `16`     | Grid width in cells.                                      |
+| `rows`    | `number`                      | `7`      | Grid height. Seven matches a real weekday graph.          |
 
 The five activity levels are themable via `--vp-c-tile-0` … `--vp-c-tile-4`.
 Level 0 is transparent by default so the grid tints nothing behind it.

--- a/packages/demo/src/guide/components.md
+++ b/packages/demo/src/guide/components.md
@@ -366,6 +366,10 @@ The decorative grid behind the footer — a GitHub contribution graph rendered
 from a deterministic hash, so the server and client always produce the same
 pattern. Useful on its own for any band that wants the same texture.
 
+Two masks are intersected so the grid reads as a chevron pointing inwards:
+one fades it towards the page centre (which edge depends on `side`), the other
+hollows out the vertical middle so text placed over it stays legible.
+
 ```vue
 <script setup>
 import { VPContributionTiles } from 'vitepress-carbon/components'

--- a/packages/demo/src/guide/components.md
+++ b/packages/demo/src/guide/components.md
@@ -330,6 +330,59 @@ const links = [
 | ------- | -------------- | --------------------------------------------------------------------- |
 | `links` | `SocialLink[]` | `icon` is a built-in name (`github`, `discord`, `x`, …) or `{ svg }`. |
 
+### VPFooter
+
+The site footer: an optional call to action, a message and a copyright line,
+with contribution-graph tiles bleeding off either edge. It renders only on
+pages without a sidebar, and is driven entirely by `themeConfig.footer` — you
+normally configure it rather than importing it.
+
+```ts
+// .vitepress/config.mts
+themeConfig: {
+  footer: {
+    action: {
+      text: 'Create Repository',
+      link: 'https://github.com/new',
+      theme: 'brand' // 'brand' | 'alt' | 'sponsor', defaults to 'brand'
+    },
+    message: 'Released under the <a href="/LICENSE">MIT License</a>.',
+    copyright: `Copyright © 2024–${new Date().getFullYear()} You`
+  }
+}
+```
+
+| Key         | Type     | Description                                      |
+| ----------- | -------- | ------------------------------------------------ |
+| `action`    | `object` | Optional CTA above the message. Omit to hide it. |
+| `message`   | `string` | Supports inline HTML.                            |
+| `copyright` | `string` | Supports inline HTML.                            |
+
+Set `footer: false` in a page's frontmatter to hide it on that page.
+
+### VPContributionTiles
+
+The decorative grid behind the footer — a GitHub contribution graph rendered
+from a deterministic hash, so the server and client always produce the same
+pattern. Useful on its own for any band that wants the same texture.
+
+```vue
+<script setup>
+import { VPContributionTiles } from 'vitepress-carbon/components'
+</script>
+
+<VPContributionTiles side="left" :columns="20" :rows="22" />
+```
+
+| Prop      | Type                | Default  | Description                                      |
+| --------- | ------------------- | -------- | ------------------------------------------------ |
+| `side`    | `'left' \| 'right'` | `'left'` | Edge the grid fades away from.                   |
+| `columns` | `number`            | `16`     | Grid width in cells.                             |
+| `rows`    | `number`            | `7`      | Grid height. Seven matches a real weekday graph. |
+
+The five activity levels are themable via `--vp-c-tile-0` … `--vp-c-tile-4`.
+Level 0 is transparent by default so the grid tints nothing behind it.
+
 ## Composables
 
 The theme entry also exports two composables:

--- a/packages/theme/src/theme/CarbonTheme.ts
+++ b/packages/theme/src/theme/CarbonTheme.ts
@@ -459,6 +459,12 @@ export namespace CarbonTheme {
   export interface Footer {
     message?: string
     copyright?: string
+    /** Optional call to action rendered above the message. */
+    action?: {
+      text: string
+      link: string
+      theme?: 'brand' | 'alt' | 'sponsor'
+    }
   }
 
   // team ----------------------------------------------------------------------

--- a/packages/theme/src/theme/components/VPContributionTiles.vue
+++ b/packages/theme/src/theme/components/VPContributionTiles.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    /** Which edge the grid fades away from. */
+    side?: 'left' | 'right'
+    columns?: number
+    /**
+     * GitHub's graph is seven rows — one per weekday. Pass more when the grid
+     * is decorative and needs to fill a taller band.
+     */
+    rows?: number
+  }>(),
+  { side: 'left', columns: 16, rows: 7 }
+)
+
+/**
+ * Deterministic value in [0, 1) for a cell. Math.random() would produce a
+ * different grid on the server than on the client and break hydration, so
+ * this hashes the coordinates instead.
+ */
+function noise(col: number, row: number, seed: number) {
+  const n = Math.sin(col * 12.9898 + row * 78.233 + seed * 37.719) * 43758.5453
+  return n - Math.floor(n)
+}
+
+/**
+ * Weighted towards the quieter levels, the way a real contribution graph is —
+ * mostly empty with occasional bright days.
+ */
+function level(value: number) {
+  if (value < 0.42) return 0
+  if (value < 0.66) return 1
+  if (value < 0.83) return 2
+  if (value < 0.94) return 3
+  return 4
+}
+
+const cells = computed(() => {
+  const seed = props.side === 'left' ? 1 : 2
+  const out: { key: string; level: number }[] = []
+
+  for (let col = 0; col < props.columns; col++) {
+    for (let row = 0; row < props.rows; row++) {
+      out.push({ key: `${col}-${row}`, level: level(noise(col, row, seed)) })
+    }
+  }
+
+  return out
+})
+</script>
+
+<template>
+  <div
+    class="VPContributionTiles"
+    :class="side"
+    :style="{ '--columns': columns, '--rows': rows }"
+    aria-hidden="true"
+  >
+    <span
+      v-for="cell in cells"
+      :key="cell.key"
+      class="tile"
+      :data-level="cell.level"
+    />
+  </div>
+</template>
+
+<style scoped>
+.VPContributionTiles {
+  display: grid;
+  grid-template-columns: repeat(var(--columns), 11px);
+  grid-template-rows: repeat(var(--rows), 11px);
+  grid-auto-flow: column;
+  gap: 3px;
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Fade the grid out towards the middle of the footer so it reads as texture
+   behind the content rather than a chart. */
+.VPContributionTiles.left {
+  --vp-tiles-mask: linear-gradient(to right, #000 0%, transparent 92%);
+}
+
+.VPContributionTiles.right {
+  --vp-tiles-mask: linear-gradient(to left, #000 0%, transparent 92%);
+}
+
+.VPContributionTiles {
+  -webkit-mask-image: var(--vp-tiles-mask);
+  mask-image: var(--vp-tiles-mask);
+}
+
+.tile {
+  border-radius: 2px;
+  background-color: var(--vp-c-tile-0);
+}
+
+.tile[data-level='1'] {
+  background-color: var(--vp-c-tile-1);
+}
+
+.tile[data-level='2'] {
+  background-color: var(--vp-c-tile-2);
+}
+
+.tile[data-level='3'] {
+  background-color: var(--vp-c-tile-3);
+}
+
+.tile[data-level='4'] {
+  background-color: var(--vp-c-tile-4);
+}
+</style>

--- a/packages/theme/src/theme/components/VPContributionTiles.vue
+++ b/packages/theme/src/theme/components/VPContributionTiles.vue
@@ -78,19 +78,33 @@ const cells = computed(() => {
   user-select: none;
 }
 
-/* Fade the grid out towards the middle of the footer so it reads as texture
-   behind the content rather than a chart. */
 .VPContributionTiles.left {
-  --vp-tiles-mask: linear-gradient(to right, #000 0%, transparent 92%);
+  --vp-tiles-fade: linear-gradient(to right, #000 0%, transparent 88%);
 }
 
 .VPContributionTiles.right {
-  --vp-tiles-mask: linear-gradient(to left, #000 0%, transparent 92%);
+  --vp-tiles-fade: linear-gradient(to left, #000 0%, transparent 88%);
 }
 
+/* Two masks intersected: one fades towards the page centre, the other hollows
+   out the vertical middle. Together the grid reads as a chevron pointing at
+   the content — dense top and bottom, empty where the text sits — rather than
+   a solid wall of squares. */
 .VPContributionTiles {
-  -webkit-mask-image: var(--vp-tiles-mask);
-  mask-image: var(--vp-tiles-mask);
+  --vp-tiles-hollow: linear-gradient(
+    to bottom,
+    #000 0%,
+    rgba(0, 0, 0, 0.35) 26%,
+    transparent 42%,
+    transparent 58%,
+    rgba(0, 0, 0, 0.35) 74%,
+    #000 100%
+  );
+
+  -webkit-mask-image: var(--vp-tiles-fade), var(--vp-tiles-hollow);
+  mask-image: var(--vp-tiles-fade), var(--vp-tiles-hollow);
+  -webkit-mask-composite: source-in;
+  mask-composite: intersect;
 }
 
 .tile {

--- a/packages/theme/src/theme/components/VPContributionTiles.vue
+++ b/packages/theme/src/theme/components/VPContributionTiles.vue
@@ -3,7 +3,13 @@ import { computed } from 'vue'
 
 const props = withDefaults(
   defineProps<{
-    /** Which edge the grid fades away from. */
+    /**
+     * `fade` thins the grid out towards one edge; `frame` keeps the perimeter
+     * and hollows out the centre so content can sit inside it; `none` leaves
+     * the grid whole.
+     */
+    mask?: 'fade' | 'frame' | 'none'
+    /** Edge the grid fades away from. Only meaningful when mask is `fade`. */
     side?: 'left' | 'right'
     columns?: number
     /**
@@ -12,7 +18,7 @@ const props = withDefaults(
      */
     rows?: number
   }>(),
-  { side: 'left', columns: 16, rows: 7 }
+  { mask: 'fade', side: 'left', columns: 16, rows: 7 }
 )
 
 /**
@@ -54,7 +60,7 @@ const cells = computed(() => {
 <template>
   <div
     class="VPContributionTiles"
-    :class="side"
+    :class="[`mask-${mask}`, side]"
     :style="{ '--columns': columns, '--rows': rows }"
     aria-hidden="true"
   >
@@ -78,33 +84,31 @@ const cells = computed(() => {
   user-select: none;
 }
 
-.VPContributionTiles.left {
-  --vp-tiles-fade: linear-gradient(to right, #000 0%, transparent 88%);
+.VPContributionTiles.mask-fade.left {
+  -webkit-mask-image: linear-gradient(to right, #000 0%, transparent 88%);
+  mask-image: linear-gradient(to right, #000 0%, transparent 88%);
 }
 
-.VPContributionTiles.right {
-  --vp-tiles-fade: linear-gradient(to left, #000 0%, transparent 88%);
+.VPContributionTiles.mask-fade.right {
+  -webkit-mask-image: linear-gradient(to left, #000 0%, transparent 88%);
+  mask-image: linear-gradient(to left, #000 0%, transparent 88%);
 }
 
-/* Two masks intersected: one fades towards the page centre, the other hollows
-   out the vertical middle. Together the grid reads as a chevron pointing at
-   the content — dense top and bottom, empty where the text sits — rather than
-   a solid wall of squares. */
-.VPContributionTiles {
-  --vp-tiles-hollow: linear-gradient(
-    to bottom,
-    #000 0%,
-    rgba(0, 0, 0, 0.35) 26%,
-    transparent 42%,
-    transparent 58%,
-    rgba(0, 0, 0, 0.35) 74%,
+/* One ellipse punched out of the middle. The grid stays continuous around
+   every edge — top, bottom and both sides — so it reads as a closed frame
+   rather than two blocks with the centre sliced out. */
+.VPContributionTiles.mask-frame {
+  --vp-tiles-ring: radial-gradient(
+    ellipse var(--vp-tiles-hollow-w, 40%) var(--vp-tiles-hollow-h, 62%) at 50%
+      50%,
+    transparent 0%,
+    transparent 52%,
+    rgba(0, 0, 0, 0.55) 78%,
     #000 100%
   );
 
-  -webkit-mask-image: var(--vp-tiles-fade), var(--vp-tiles-hollow);
-  mask-image: var(--vp-tiles-fade), var(--vp-tiles-hollow);
-  -webkit-mask-composite: source-in;
-  mask-composite: intersect;
+  -webkit-mask-image: var(--vp-tiles-ring);
+  mask-image: var(--vp-tiles-ring);
 }
 
 .tile {

--- a/packages/theme/src/theme/components/VPFooter.vue
+++ b/packages/theme/src/theme/components/VPFooter.vue
@@ -80,7 +80,6 @@ const { hasSidebar } = useSidebar()
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  opacity: 0.65;
 }
 
 .tiles-left {
@@ -98,7 +97,7 @@ const { hasSidebar } = useSidebar()
   }
 
   .tiles-left {
-    opacity: 0.16;
+    opacity: 0.4;
   }
 }
 

--- a/packages/theme/src/theme/components/VPFooter.vue
+++ b/packages/theme/src/theme/components/VPFooter.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useData } from '../composables/data'
 import { useSidebar } from '../composables/sidebar'
+import VPButton from './VPButton.vue'
+import VPContributionTiles from './VPContributionTiles.vue'
 
 const { theme, frontmatter } = useData()
 const { hasSidebar } = useSidebar()
@@ -12,7 +14,30 @@ const { hasSidebar } = useSidebar()
     class="VPFooter"
     :class="{ 'has-sidebar': hasSidebar }"
   >
+    <VPContributionTiles
+      class="tiles tiles-left"
+      side="left"
+      :columns="20"
+      :rows="22"
+    />
+    <VPContributionTiles
+      class="tiles tiles-right"
+      side="right"
+      :columns="20"
+      :rows="22"
+    />
+
     <div class="container">
+      <div v-if="theme.footer.action" class="action">
+        <VPButton
+          tag="a"
+          size="medium"
+          :theme="theme.footer.action.theme ?? 'brand'"
+          :text="theme.footer.action.text"
+          :href="theme.footer.action.link"
+        />
+      </div>
+
       <p
         v-if="theme.footer.message"
         class="message"
@@ -31,12 +56,79 @@ const { hasSidebar } = useSidebar()
 .VPFooter {
   position: relative;
   z-index: var(--vp-z-index-footer);
-  padding: 32px 24px;
+  overflow: hidden;
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 48px 24px;
   background-color: var(--vp-c-bg);
 }
 
 .VPFooter.has-sidebar {
   display: none;
+}
+
+@media (min-width: 768px) {
+  .VPFooter {
+    padding: 56px 32px;
+  }
+}
+
+/* Tiles sit behind the content and are clipped by the footer's overflow, so
+   they read as texture bleeding off both edges. */
+/* Deliberately taller than the footer so the grid bleeds off top and bottom
+   instead of floating in the middle; overflow: hidden does the trimming. */
+.tiles {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0.65;
+}
+
+.tiles-left {
+  left: -16px;
+}
+
+.tiles-right {
+  right: -16px;
+}
+
+/* Below the point where the grids would crowd the text, thin them out. */
+@media (max-width: 1099px) {
+  .tiles-right {
+    display: none;
+  }
+
+  .tiles-left {
+    opacity: 0.16;
+  }
+}
+
+@media (max-width: 767px) {
+  .tiles {
+    display: none;
+  }
+}
+
+.container {
+  position: relative;
+  margin: 0 auto;
+  max-width: var(--vp-layout-max-width);
+  text-align: center;
+}
+
+.action {
+  margin-bottom: 24px;
+}
+
+/* Square-cornered like the nav bar's button rather than VPButton's pill, but
+   sized up — this is the page's closing call to action. */
+.action :deep(.VPButton) {
+  display: inline-flex;
+  align-items: center;
+  height: 44px;
+  border-radius: var(--vp-nav-control-radius);
+  padding: 0 24px;
+  line-height: 1;
+  font-size: 15px;
 }
 
 .VPFooter :deep(a) {
@@ -49,16 +141,10 @@ const { hasSidebar } = useSidebar()
   color: var(--vp-c-text-1);
 }
 
-@media (min-width: 768px) {
-  .VPFooter {
-    padding: 32px;
-  }
-}
-
-.container {
-  margin: 0 auto;
-  max-width: var(--vp-layout-max-width);
-  text-align: center;
+/* The CTA is a button, not body copy — keep the link underline off it. */
+.action :deep(a),
+.action :deep(a:hover) {
+  text-decoration-line: none;
 }
 
 .message,
@@ -67,5 +153,9 @@ const { hasSidebar } = useSidebar()
   font-size: 14px;
   font-weight: 500;
   color: var(--vp-c-text-2);
+}
+
+.copyright {
+  margin-top: 4px;
 }
 </style>

--- a/packages/theme/src/theme/components/VPFooter.vue
+++ b/packages/theme/src/theme/components/VPFooter.vue
@@ -14,18 +14,7 @@ const { hasSidebar } = useSidebar()
     class="VPFooter"
     :class="{ 'has-sidebar': hasSidebar }"
   >
-    <VPContributionTiles
-      class="tiles tiles-left"
-      side="left"
-      :columns="20"
-      :rows="22"
-    />
-    <VPContributionTiles
-      class="tiles tiles-right"
-      side="right"
-      :columns="20"
-      :rows="22"
-    />
+    <VPContributionTiles class="tiles" mask="frame" :columns="120" :rows="18" />
 
     <div class="container">
       <div v-if="theme.footer.action" class="action">
@@ -74,36 +63,28 @@ const { hasSidebar } = useSidebar()
 
 /* Tiles sit behind the content and are clipped by the footer's overflow, so
    they read as texture bleeding off both edges. */
-/* Deliberately taller than the footer so the grid bleeds off top and bottom
-   instead of floating in the middle; overflow: hidden does the trimming. */
+/* Deliberately larger than the footer in both axes so the grid bleeds off
+   every edge and never ends on a sliced cell; overflow: hidden trims it. */
 .tiles {
   position: absolute;
   top: 50%;
-  transform: translateY(-50%);
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
-.tiles-left {
-  left: -16px;
-}
-
-.tiles-right {
-  right: -16px;
-}
-
-/* Below the point where the grids would crowd the text, thin them out. */
+/* Narrower viewports leave less room between the frame and the text, so pull
+   the hollow wider and soften the grid. */
 @media (max-width: 1099px) {
-  .tiles-right {
-    display: none;
-  }
-
-  .tiles-left {
-    opacity: 0.4;
+  .tiles {
+    --vp-tiles-hollow-w: 58%;
+    opacity: 0.55;
   }
 }
 
 @media (max-width: 767px) {
   .tiles {
-    display: none;
+    --vp-tiles-hollow-w: 76%;
+    opacity: 0.35;
   }
 }
 

--- a/packages/theme/src/theme/styles/vars.css
+++ b/packages/theme/src/theme/styles/vars.css
@@ -403,13 +403,16 @@
 :root {
   --vp-button-brand-border: rgba(240, 246, 252, 0.1);
   --vp-button-brand-text: var(--vp-c-white);
-  --vp-button-brand-bg: var(--vp-c-green-1);
+  /* GitHub's primary-button greens. --vp-c-green-1 (#3fb950) is tuned for
+     icons and accents; behind white label text it only reaches 2.5:1, short
+     of WCAG AA. These clear it. */
+  --vp-button-brand-bg: #1f883d;
   --vp-button-brand-hover-border: rgba(240, 246, 252, 0.1);
   --vp-button-brand-hover-text: var(--vp-c-white);
-  --vp-button-brand-hover-bg: #41ad4f;
+  --vp-button-brand-hover-bg: #1a7f37;
   --vp-button-brand-active-border: rgba(240, 246, 252, 0.1);
   --vp-button-brand-active-text: var(--vp-c-white);
-  --vp-button-brand-active-bg: #42c754;
+  --vp-button-brand-active-bg: #197935;
 
   --vp-button-alt-border: var(--vp-c-border);
   --vp-button-alt-text: var(--vp-c-text-1);
@@ -588,6 +591,15 @@
     radial-gradient(circle at 78% 18%, rgba(63, 185, 80, 0.08), transparent 26%);
   --vp-home-hero-glow: rgba(63, 185, 80, 0.1);
 
+  /* Contribution-graph tiles behind the footer, mirroring GitHub's five
+     activity levels. Level 0 stays transparent — a filled "empty day" tints
+     the whole band and reads as the footer having a different background. */
+  --vp-c-tile-0: transparent;
+  --vp-c-tile-1: #9be9a8;
+  --vp-c-tile-2: #40c463;
+  --vp-c-tile-3: #30a14e;
+  --vp-c-tile-4: #216e39;
+
   --vp-home-hero-image-background-image: none;
   --vp-home-hero-image-filter: none;
 }
@@ -609,6 +621,12 @@
     ),
     radial-gradient(circle at 78% 18%, rgba(63, 185, 80, 0.1), transparent 24%);
   --vp-home-hero-glow: rgba(63, 185, 80, 0.16);
+
+  --vp-c-tile-0: transparent;
+  --vp-c-tile-1: #0e4429;
+  --vp-c-tile-2: #006d32;
+  --vp-c-tile-3: #26a641;
+  --vp-c-tile-4: #39d353;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #293 — these two commits landed on that branch just after it was merged, so they never made it into `main`.

Gives `VPFooter` a GitHub contribution-graph backdrop, a configurable call to action, and the year/licence line in the middle.

### What's new
- **`themeConfig.footer.action`** — an optional CTA above the message (`text`, `link`, `theme`). Square-cornered like the nav bar's button but sized up at 44px, since it's the page's closing CTA.
- **`VPContributionTiles`** — the grid, generated from a deterministic hash of each cell's coordinates. `Math.random()` would differ between server and client and break hydration. Props: `side`, `columns`, `rows`.

Both are exported from `vitepress-carbon/components` and documented in the Built-in Components guide.

### Two things that needed fixing along the way
- **The footer looked like it had a different background.** It didn't — measured identical to the page at `rgb(13,17,23)`. The cause was level-0 ("no commits") tiles being filled with a colour *lighter* than the page, tinting the whole band. Level 0 is now transparent.
- **`--vp-button-brand-bg` failed WCAG AA.** It was `--vp-c-green-1` (`#3fb950`), which under white label text reaches only **2.54:1**. Moved the brand button to GitHub's primary greens (`#1f883d`), taking the footer CTA *and the pre-existing hero button* to **4.52:1**. `--vp-c-green-1` itself is unchanged, so icons and accents keep their colour.

### Shape
The grid is deliberately taller than the footer so it bleeds off top and bottom rather than floating with dead space. Two masks are intersected — a horizontal fade towards the page centre and a vertical hollow through the middle — so it reads as a chevron framing the content, and can run at full opacity without competing with the text.

Verified in light and dark. `pnpm check`, `pnpm test` (6/6) and `pnpm build` pass.