### PR TITLE
feat(theme): make the nav bar follow the colour scheme

### DIFF
--- a/.changeset/nav-follows-colour-mode.md
+++ b/.changeset/nav-follows-colour-mode.md
@@ -1,0 +1,22 @@
+---
+'vitepress-carbon': minor
+---
+
+The nav bar now follows the colour scheme instead of staying dark in light mode.
+
+`VPNav` and `VPNavBar` were painted with `--vp-c-bg-dark` and their text with
+`--vp-c-text-dark`, both `:root`-only values, so the header stayed a dark slab
+above white content in light mode. They now use `--vp-nav-bg-color`
+(`--vp-c-bg-alt`), which the mobile nav screen already used, so the bar and the
+screen are one continuous surface in both modes.
+
+The `--vp-c-nav-*` foreground tokens gained proper light values and a `.dark`
+block carrying the previous ones, so **dark mode is unchanged**: nav background
+`#010409`, wordmark 17.4:1, icons 9.7:1, all identical to before. Light mode goes
+from a near-white foreground on a near-white screen to wordmark 14.6:1 and icons
+5.7:1.
+
+New token `--vp-c-nav-title` for prominent nav text; it resolves to
+`--vp-c-text-dark` in dark mode, so existing overrides of that variable still
+apply. This supersedes the `VPNavScreen` token override added alongside it —
+the tokens are now correct for that surface without one.

--- a/packages/theme/src/theme/components/VPNav.vue
+++ b/packages/theme/src/theme/components/VPNav.vue
@@ -61,7 +61,7 @@ watchEffect(() => {
   z-index: var(--vp-z-index-nav);
   width: 100%;
   pointer-events: none;
-  background-color: var(--vp-c-bg-dark);
+  background-color: var(--vp-nav-bg-color);
   transition: background-color 0.5s;
 }
 

--- a/packages/theme/src/theme/components/VPNavBar.vue
+++ b/packages/theme/src/theme/components/VPNavBar.vue
@@ -85,16 +85,16 @@ watchPostEffect(() => {
   white-space: nowrap;
   transition: background-color 0.5s;
   box-shadow: inset 0 calc(max(1px, 0.0625rem) * -1) var(--vp-c-border);
-  color: var(--vp-c-text-dark);
+  color: var(--vp-c-nav-title);
 }
 
 .VPNavBar.has-local-nav {
-  background-color: var(--vp-c-bg-dark);
+  background-color: var(--vp-nav-bg-color);
 }
 
 @media (min-width: 768px) {
   .VPNavBar:not(.has-sidebar):not(.top) {
-    background-color: var(--vp-c-bg-dark);
+    background-color: var(--vp-nav-bg-color);
   }
 }
 

--- a/packages/theme/src/theme/components/VPNavBarSearchButton.vue
+++ b/packages/theme/src/theme/components/VPNavBarSearchButton.vue
@@ -143,7 +143,7 @@ const translate = createSearchTranslate(defaultTranslations)
   position: relative;
   width: 16px;
   height: 16px;
-  color: var(--vp-c-text-dark);
+  color: var(--vp-c-nav-title);
   fill: currentColor;
   transition: 80ms cubic-bezier(0.33, 1, 0.68, 1);
   transition-property: color, background-color, box-shadow, border-color;

--- a/packages/theme/src/theme/components/VPNavBarTitle.vue
+++ b/packages/theme/src/theme/components/VPNavBarTitle.vue
@@ -70,7 +70,7 @@ const target = computed(() =>
   line-height: 1.4285714286;
   font-size: 14px;
   font-weight: 600;
-  color: var(--vp-c-text-dark);
+  color: var(--vp-c-nav-title);
   transition: opacity 0.25s;
 }
 

--- a/packages/theme/src/theme/components/VPNavScreen.vue
+++ b/packages/theme/src/theme/components/VPNavScreen.vue
@@ -50,16 +50,8 @@ const isLocked = useScrollLock(inBrowser ? document.body : null)
   overflow-y: auto;
   transition: background-color 0.5s;
   pointer-events: auto;
-
-  /* The `--vp-c-nav-*` tokens describe foreground on the nav *bar*, which is a
-     dark surface in both colour schemes. This screen sits on `--vp-c-bg-alt`
-     instead — near-white in light mode — so inheriting them rendered the social
-     icons at 1.07:1 against their own background. Re-point them at the ordinary
-     text roles, which are defined for both modes. */
-  --vp-c-nav-text: var(--vp-c-text-2);
-  --vp-c-nav-text-hover: var(--vp-c-text-1);
-  --vp-c-nav-hover-bg: var(--vp-c-default-soft);
-  --vp-c-nav-hover-border: var(--vp-c-border);
+  /* Shares `--vp-c-bg-alt` with the nav bar, so the `--vp-c-nav-*` foreground
+     tokens are already correct here — no local override needed. */
 }
 
 .VPNavScreen.fade-enter-active,

--- a/packages/theme/src/theme/styles/vars.css
+++ b/packages/theme/src/theme/styles/vars.css
@@ -513,21 +513,33 @@
   --color-action-list-item-default-active-border: rgba(111, 122, 131, 0.75);
   --color-action-list-item-default-selected-bg: rgba(177, 186, 196, 0.08);
 
-  /* Foreground on the nav *bar*, which is `--vp-c-bg-dark` — dark in both
-     colour schemes — so these hold regardless of `.dark`. Items rest borderless
-     and gain definition on hover.
-     They are not general-purpose: any surface that is not the dark bar must
-     re-point them at the ordinary text roles, as `.VPNavScreen` does. */
-  --vp-c-nav-text: rgba(230, 237, 243, 0.75);
-  --vp-c-nav-text-hover: rgb(230, 237, 243);
-  --vp-c-nav-hover-bg: rgba(177, 186, 196, 0.12);
-  --vp-c-nav-hover-border: rgba(240, 246, 252, 0.12);
-  --vp-c-nav-active-bg: rgba(177, 186, 196, 0.2);
+  /* Foreground on the nav surface (`--vp-nav-bg-color`, shared by the bar and
+     the mobile screen). That surface follows the colour scheme, so these need a
+     value in each mode — see the `.dark` block. Items rest borderless and gain
+     definition on hover. */
+  --vp-c-nav-title: var(--vp-c-text-1);
+  --vp-c-nav-text: var(--vp-c-text-2);
+  --vp-c-nav-text-hover: var(--vp-c-text-1);
+  --vp-c-nav-hover-bg: var(--vp-c-default-soft);
+  --vp-c-nav-hover-border: var(--vp-c-border);
+  --vp-c-nav-active-bg: var(--vp-c-gray-soft);
 
   /* Every interactive control in the nav bar — search, menu items, buttons,
      icon buttons — shares this box so the row reads as one strip. */
   --vp-nav-control-height: 32px;
   --vp-nav-control-radius: 6px;
+}
+
+.dark {
+  /* On the dark nav surface the foreground runs brighter than the body text
+     roles so the strip keeps its contrast against `--vp-c-bg-alt` (#010409).
+     `--vp-c-text-dark` stays the override point it has always been. */
+  --vp-c-nav-title: var(--vp-c-text-dark);
+  --vp-c-nav-text: rgba(230, 237, 243, 0.75);
+  --vp-c-nav-text-hover: rgb(230, 237, 243);
+  --vp-c-nav-hover-bg: rgba(177, 186, 196, 0.12);
+  --vp-c-nav-hover-border: rgba(240, 246, 252, 0.12);
+  --vp-c-nav-active-bg: rgba(177, 186, 196, 0.2);
 }
 
 .hide-nav {


### PR DESCRIPTION
Stacked on #295 — review that one first. GitHub will retarget this to `main` when #295 merges.

## Why

The header was painted with `--vp-c-bg-dark` and its text with `--vp-c-text-dark`. Both are declared once in `:root` holding dark-surface values with no `.dark` counterpart, so in light mode a dark slab sat above white content — the tonal break that made light mode feel unfinished.

That also violated design.md principle 3, *"One system, two modes. Every token has a light and a dark value."*

## What changed

`VPNav` / `VPNavBar` now use **`--vp-nav-bg-color`** — a token that already existed for the mobile nav screen but which the bar never used. So the bar and the screen are now one continuous surface in both schemes, rather than a dark bar meeting a white menu.

The `--vp-c-nav-*` foreground tokens gained light values, plus a `.dark` block carrying the previous ones verbatim.

New token `--vp-c-nav-title` for prominent nav text. It resolves to `--vp-c-text-dark` under `.dark`, so any site overriding that variable keeps its customisation.

## Dark mode is unchanged

Measured on the built demo, before vs after:

| | light (before) | light (after) | dark (before) | dark (after) |
| --- | --- | --- | --- | --- |
| nav surface | `#24292f` | `#f6f6f7` | `#010409` | `#010409` |
| wordmark | 5.9:1 on dark slab | **14.63:1** | 17.38:1 | **17.38:1** |
| nav icons | 1.07:1 *(invisible)* | **5.66:1** | 9.68:1 | **9.68:1** |

Dark numbers are identical. Light-mode icons were below the 3:1 WCAG minimum for non-text contrast and are now comfortably clear of it.

## Supersedes the VPNavScreen override

#295 fixed the invisible icons by re-pointing the tokens locally on `.VPNavScreen`. With the tokens now mode-aware and the screen sharing the bar's surface, that override is redundant, so this PR removes it. The fix stays in #295 on its own merits — it added the Storybook social icon, which is one of the two that vanish, so #295 should not ship without it.

## Not included

design.md's `border.muted` role (`#d1d9e0b3`) is still mapped to the same value as `border.default` in light mode, so "softer separators" doesn't exist as a distinct weight. Worth a follow-up; left out here to keep this PR to one idea.

`pnpm check`, `pnpm test` (73), and `pnpm build` all pass. Verified in a real browser at desktop and mobile widths, in both schemes.