### PR TITLE
fix(theme): stop the footer tile grid from being cut off

### DIFF
--- a/.changeset/footer-tiles-fit.md
+++ b/.changeset/footer-tiles-fit.md
@@ -1,0 +1,18 @@
+---
+'vitepress-carbon': patch
+---
+
+Stop the footer's contribution-tile grid from being cut off.
+
+The grid was a fixed 120x18 of 11px cells on a 3px gap — 1677x249px — centred
+inside a footer that is neither of those sizes. Below 1677px wide the extra was
+trimmed by `overflow: hidden`, and because the offset is arbitrary the cut
+landed mid-cell: across viewports from 320px to 2560px, 46% sliced a column in
+half, and the vertical cut sliced a row at almost every height. Above 1677px the
+grid instead stopped short of both edges, reading as a floating rectangle rather
+than texture.
+
+`VPContributionTiles` now takes a `fit` prop that sizes the grid to its own box
+in whole cells, and the footer fills its box (`inset: 0`) instead of centring a
+fixed grid. The leftover is always under one 14px pitch and is split between the
+opposite edges, so no tile is ever clipped at any viewport size.

--- a/packages/theme/src/theme/components/VPContributionTiles.vue
+++ b/packages/theme/src/theme/components/VPContributionTiles.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 
 const props = withDefaults(
   defineProps<{
@@ -17,9 +17,60 @@ const props = withDefaults(
      * is decorative and needs to fill a taller band.
      */
     rows?: number
+    /**
+     * Size the grid to its own box instead of using `columns`/`rows`, so it
+     * covers the container in whole cells at any viewport. `columns`/`rows`
+     * still seed the server-rendered markup, before a measurement exists.
+     */
+    fit?: boolean
   }>(),
-  { mask: 'fade', side: 'left', columns: 16, rows: 7 }
+  { mask: 'fade', side: 'left', columns: 16, rows: 7, fit: false }
 )
+
+/** Track geometry, mirrored by the grid rules in the style block below. */
+const CELL = 11
+const GAP = 3
+const PITCH = CELL + GAP
+
+/**
+ * How many whole cells fit across `size`. `n` cells span `n * CELL + (n - 1) *
+ * GAP`, so this is the largest `n` whose span still fits — the remainder is
+ * always under one pitch and gets split by the centring in the style block.
+ * Flooring is the whole point: a grid sized to *cover* its box would be clipped
+ * mid-cell, which is what left sliced tiles along every footer edge.
+ */
+function fitCount(size: number) {
+  return Math.max(1, Math.floor((size + GAP) / PITCH))
+}
+
+const root = ref<HTMLElement>()
+const measured = ref<{ columns: number; rows: number } | null>(null)
+
+let observer: ResizeObserver | undefined
+
+onMounted(() => {
+  // `onMounted` never runs during SSR, and the observer is only reached when a
+  // caller opts into `fit`; the capability check covers test environments that
+  // render with `fit` but stub out layout.
+  if (!props.fit || !root.value || typeof ResizeObserver === 'undefined') return
+
+  observer = new ResizeObserver((entries) => {
+    const box = entries[0]?.contentRect
+    if (!box) return
+
+    measured.value = {
+      columns: fitCount(box.width),
+      rows: fitCount(box.height)
+    }
+  })
+
+  observer.observe(root.value)
+})
+
+onBeforeUnmount(() => observer?.disconnect())
+
+const columns = computed(() => measured.value?.columns ?? props.columns)
+const rows = computed(() => measured.value?.rows ?? props.rows)
 
 /**
  * Deterministic value in [0, 1) for a cell. Math.random() would produce a
@@ -47,8 +98,8 @@ const cells = computed(() => {
   const seed = props.side === 'left' ? 1 : 2
   const out: { key: string; level: number }[] = []
 
-  for (let col = 0; col < props.columns; col++) {
-    for (let row = 0; row < props.rows; row++) {
+  for (let col = 0; col < columns.value; col++) {
+    for (let row = 0; row < rows.value; row++) {
       out.push({ key: `${col}-${row}`, level: level(noise(col, row, seed)) })
     }
   }
@@ -59,8 +110,9 @@ const cells = computed(() => {
 
 <template>
   <div
+    ref="root"
     class="VPContributionTiles"
-    :class="[`mask-${mask}`, side]"
+    :class="[`mask-${mask}`, side, { fit }]"
     :style="{ '--columns': columns, '--rows': rows }"
     aria-hidden="true"
   >
@@ -82,6 +134,13 @@ const cells = computed(() => {
   gap: 3px;
   pointer-events: none;
   user-select: none;
+}
+
+/* Centres the tracks in the box so the sub-pitch remainder is split between
+   the two edges rather than pooling at one of them. */
+.VPContributionTiles.fit {
+  justify-content: center;
+  align-content: center;
 }
 
 .VPContributionTiles.mask-fade.left {

--- a/packages/theme/src/theme/components/VPFooter.vue
+++ b/packages/theme/src/theme/components/VPFooter.vue
@@ -14,7 +14,13 @@ const { hasSidebar } = useSidebar()
     class="VPFooter"
     :class="{ 'has-sidebar': hasSidebar }"
   >
-    <VPContributionTiles class="tiles" mask="frame" :columns="120" :rows="18" />
+    <VPContributionTiles
+      class="tiles"
+      mask="frame"
+      fit
+      :columns="120"
+      :rows="18"
+    />
 
     <div class="container">
       <div v-if="theme.footer.action" class="action">
@@ -61,15 +67,17 @@ const { hasSidebar } = useSidebar()
   }
 }
 
-/* Tiles sit behind the content and are clipped by the footer's overflow, so
-   they read as texture bleeding off both edges. */
-/* Deliberately larger than the footer in both axes so the grid bleeds off
-   every edge and never ends on a sliced cell; overflow: hidden trims it. */
+/* Tiles sit behind the content and span the whole footer.
+
+   They used to be a fixed 120x18 grid centred with a transform, which is
+   1677x249px against a footer that is neither. Wider than that and the grid
+   stopped short of both edges; narrower and `overflow: hidden` sliced it
+   mid-cell — across 320-2560px, 46% of widths cut a column in half. Filling
+   the footer and letting the component size itself (`fit`) keeps whole cells
+   at every edge, on every screen. */
 .tiles {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  inset: 0;
 }
 
 /* Narrower viewports leave less room between the frame and the text, so pull


### PR DESCRIPTION
Closes the "grid is cut on some screens, vertically and horizontally" report.

## Cause

The footer's contribution-tile grid was a **fixed** 120x18 of 11px cells on a 3px gap — **1677x249px** — centred with a transform inside a footer that is neither of those sizes.

- **Narrower than 1677px:** the excess was trimmed by the footer's `overflow: hidden`. Because the overflow is `(1677 - width) / 2`, an arbitrary number, the cut lands wherever it lands. Sweeping 320-2560px, **46% of widths slice a column in half**; the vertical cut slices a row at nearly every height.
- **Wider than 1677px:** the grid instead stops short of both edges and reads as a floating rectangle rather than texture — this is what the reported screenshot shows at ~1888px.

The source comment asserted the grid was *"deliberately larger than the footer in both axes so it never ends on a sliced cell"*. That only holds while the footer is smaller than the fixed grid, and even then only when the overflow happens to be a whole multiple of the 14px pitch.

## Fix

`VPContributionTiles` gains a `fit` prop. When set, it measures its own box with a `ResizeObserver` and derives the track counts from it:

```
n = floor((size + gap) / pitch)
```

Flooring is the point — `n` cells span `n * pitch - gap`, which is always ≤ the box, so nothing can be clipped. The leftover is under one 14px pitch and is split between opposite edges by centring the tracks. The footer fills its box with `inset: 0` and opts in.

`columns` / `rows` still seed the server-rendered markup, so SSR output is unchanged and the measurement only refines it after mount. `onMounted` never runs during SSR, and there's a capability check so a test environment without `ResizeObserver` degrades to the seeded grid rather than throwing.

## Verified

Measured on the built demo — clipped tiles counted by comparing every tile's rect against the footer's:

| viewport | tracks | tiles | clipped | left / right inset |
| --- | --- | --- | --- | --- |
| 375 | 27 x 15 | 405 | **0** | 0 / 0 |
| 1024 | 73 x 16 | — | **0** | 2.5 / 2.5 |
| 1367 | 97 x 16 | 1552 | **0** | — |
| 1888 | 135 x 16 | 2160 | **0** | 1 / 1 |

Previously at 375px the grid overflowed by 651px per side and cut 7px into a 14px pitch horizontally, 2px vertically — sliced on all four edges.

`pnpm check` (238 files), `pnpm test` (73) and `pnpm build` all pass.

## Note

Only one component consumes `VPContributionTiles` (`VPFooter`), so the sizing change has no other callers. `fit` defaults to `false`, leaving the existing fixed-grid behaviour intact for anyone using the component directly.